### PR TITLE
Feature: Add modifier for debug drawer contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ If you want to modify the drawer colors, use `DebugDrawerDefaults.colors.copy(..
 
 ### Modules list UI
 
-Update module UI by pass `Modifier`
+Update each module's UI by passing a `Modifier`
 
 ```kotlin
 DebugDrawerLayout(
@@ -190,6 +190,18 @@ DebugDrawerLayout(
             .background(color = MaterialTheme.colors.surface)
         DeviceModule(modulesModifier)
         BuildModule(modulesModifier)
+    }
+)
+```
+
+Or configure the whole contents by specifying a `drawerContentModifier`
+
+```kotlin
+DebugDrawerLayout(
+    drawerContentModifier = Modifier.padding(16.dp),
+    drawerModules = {
+        DeviceModule()
+        BuildModule()
     }
 )
 ```

--- a/drawer-base/src/main/java/com/alorma/drawer_base/DebugDrawer.kt
+++ b/drawer-base/src/main/java/com/alorma/drawer_base/DebugDrawer.kt
@@ -158,6 +158,7 @@ fun DebugDrawerLayout(
     drawerColors: Colors = DebugDrawerDefaults.Colors,
     drawerShape: Shape = MaterialTheme.shapes.large,
     drawerElevation: Dp = DebugDrawerDefaults.Elevation,
+    drawerContentModifier: Modifier = Modifier,
     drawerModules: @Composable ColumnScope.(DebugDrawerState) -> Unit = { },
     bodyContent: @Composable (DebugDrawerState) -> Unit,
 ) {
@@ -230,7 +231,11 @@ fun DebugDrawerLayout(
                     shape = drawerShape,
                     elevation = drawerElevation
                 ) {
-                    Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    Column(
+                        modifier = Modifier
+                            .verticalScroll(rememberScrollState())
+                            .then(drawerContentModifier)
+                    ) {
                         drawerModules(debugDrawerState)
                     }
                 }


### PR DESCRIPTION
This allows callers to modify the drawer content container. An example use case for this is adding padding - especially useful if the calling app renders behind the status and navigation bars.